### PR TITLE
fix output to stale process info

### DIFF
--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -481,7 +481,7 @@ class TestRunner extends EmittingTestRunner {
           if (!testsById.has(data.id)) {
             continue; //not a test process
           }
-          const fileName = testsById.has(data.id);
+          const fileName = testsById.get(data.id)?.path;
 
           if (data.receivedOk) {
             console.error('Stale process', pid, fileName);


### PR DESCRIPTION
Fix message including filename

from (example)

```
...
Stale process 1867860 true
Stale process 1867871 true
Stale process 1867872 true
...
```

to (example)

```
Stale process 1867860 /src/__tests__/example-01.test.ts
Stale process 1867871 /src/__tests__/example-02.test.ts
Stale process 1867872 /src/__tests__/example-03.test.ts
```